### PR TITLE
Fix for error vendor/magento/module-configurable-product/Model/Product/Type/VariationMatrix.php on line 3

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/VariationMatrix.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/VariationMatrix.php
@@ -40,7 +40,9 @@ class VariationMatrix
             for ($attributeIndex = $attributesCount; $attributeIndex--;) {
                 $currentAttribute = $variationalAttributes[$attributeIndex];
                 $currentVariationValue = $currentVariation[$attributeIndex];
-                $filledVariation[$currentAttribute['id']] = $currentAttribute['values'][$currentVariationValue];
+                if(isset($currentAttribute['id']) && $currentAttribute['id']) {
+                    $filledVariation[$currentAttribute['id']] = $currentAttribute['values'][$currentVariationValue]; 
+                } 
             }
 
             $variations[] = $filledVariation;


### PR DESCRIPTION
Problem with configurables when the simple products that were associated did not have a value for the configurable attribute.
Fix this issue https://github.com/magento/magento2/issues/14240

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14240: /vendor/magento/module-configurable-product/Model/Product/Type/VariationMatrix.php on line 43 #14240


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ x] Pull request has a meaningful description of its purpose
 - [x ] All commits are accompanied by meaningful commit messages
 - [ x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x] All automated tests passed successfully (all builds are green)
